### PR TITLE
[Issue] the x-axis and y-axis values ​​are not displayed when the border width is set.

### DIFF
--- a/Source/Charts/Renderers/BarChartRenderer.swift
+++ b/Source/Charts/Renderers/BarChartRenderer.swift
@@ -322,7 +322,6 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
             
             if drawBorder
             {
-                context.saveGState()
                 context.setStrokeColor(borderColor.cgColor)
                 context.setLineWidth(borderWidth)
                 context.stroke(barRect)


### PR DESCRIPTION
### Description

If you set the border width value on the bar in the bar chart, the x-axis and y-axis values ​​are not displayed properly.

Please refer to below

When the border width value is set.
![image](https://user-images.githubusercontent.com/30803503/77173429-da03a500-6b02-11ea-9c3e-c41c67b3ba6a.png)


the x-axis and y-axis values ​​are not displayed properly.
![image](https://user-images.githubusercontent.com/30803503/77173457-e2f47680-6b02-11ea-8b7a-dda6a270377d.png)
